### PR TITLE
Update upload file to 'v2'

### DIFF
--- a/reporting/slack.py
+++ b/reporting/slack.py
@@ -7,4 +7,4 @@ def slack(emails, csv_file_path, slack_bot_token):
     for email in emails:
         user_data = client.users_lookupByEmail(email=email)
         with open(csv_file_path, 'rb') as csvfile:
-            client.files_upload(file=csvfile, channels=[user_data["user"]["id"]])
+            client.files_upload_v2(file=csvfile, channels=[user_data["user"]["id"]])


### PR DESCRIPTION
There maybe an issue with sending the report file now it is getting larger due to the number of entries in the report

The reporting lambda is throwing this warning message:

'var/task/slack_sdk/web/internal_utils.py:450: UserWarning: client.files_upload() may cause some issues like timeouts for relatively large files. Our latest recommendation is to use client.files_upload_v2(), which is mostly compatible and much stabler, instead.'