### PR TITLE
Fix issue

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,4 +52,4 @@ jobs:
           role-session-name: ECRLogin
       - name: run lambda function
         run: |
-          aws lambda invoke --function-name tdr-reporting-${{ inputs.environment }} --cli-binary-format raw-in-base64-out --payload '{"emails": [${{ inputs.emails }}],"reportType": "${{ inputs.reportType }}"}' response.json
+          aws lambda invoke --function-name tdr-reporting-${{ inputs.environment }} --cli-read-timeout 0 --cli-binary-format raw-in-base64-out --payload '{"emails": [${{ inputs.emails }}],"reportType": "${{ inputs.reportType }}"}' response.json


### PR DESCRIPTION
Looks like GitHub creates multiple threads and somehow it locks the lambda function if another thread is running and due to this, it returns a timeout error.

`Read timeout on endpoint URL: "https://lambda.eu-west-2.amazonaws.com/2015-03-31/functions/tdr-reporting-intg/invocations"`

Added `--cli-read-timeout` to `0` to prevent timeout error.

I'm still not sure of the real root cause of the issue, we might need to revisit this issue if anything fails.