### PR TITLE
Update build dependencies

### DIFF
--- a/build-dependencies.sh
+++ b/build-dependencies.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-yum install -y wget zip
-amazon-linux-extras install python3.8
-python3.8 -m ensurepip --upgrade
+dnf install -y wget zip
+dnf install -y python3.11
+python3.11 -m ensurepip --upgrade
 
 mkdir /pip
-pip3.8 install --requirement requirements.txt --target /pip
+pip3.11 install --requirement requirements.txt --target /pip
 
 cd /pip
 rm -r *.dist-info


### PR DESCRIPTION
`amazon-linux-extras` is not available in Amazon Linux 2023.
Use DNF which is similar to YUM to install Python3.11 (available on AL2023)