### PR TITLE
TDR-2350 - Use consignment level "seriesName" field

### DIFF
--- a/reporting/model.py
+++ b/reporting/model.py
@@ -32,7 +32,7 @@ class Consignment(Type):
     transferInitiatedDatetime = Field(str)
     files = list_of(File)
     transferringBody = Field(TransferringBody)
-    series = Field(Series)
+    seriesName = Field(str)
 
 
 class Edge(Type):

--- a/reporting/report.py
+++ b/reporting/report.py
@@ -51,7 +51,7 @@ def get_query(cursor=None):
     node.createdDatetime()
     node.transferringBody()
     node.files()
-    node.series()
+    node.seriesName()
     edges.cursor()
     consignments_query.page_info.__fields__('has_next_page')
     consignments_query.page_info.__fields__(end_cursor=True)

--- a/reporting/report_types.py
+++ b/reporting/report_types.py
@@ -16,7 +16,7 @@ class StandardReport(Report):
             "ConsignmentType": node.consignmentType,
             "TransferringBodyName": node.transferringBody.name,
             "BodyCode": node.transferringBody.tdrCode,
-            "SeriesCode": node.series.code if hasattr(node.series, 'code') else '',
+            "SeriesCode": node.seriesName,
             "ConsignmentId": node.consignmentid,
             "UserId": node.userid,
             "CreatedDateTime": node.createdDatetime,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -36,10 +36,7 @@ query {
               clientSideFileSize
             }
         }
-        series {
-            code
-            name
-        }
+        seriesName
       }
       cursor
     }
@@ -55,7 +52,7 @@ graphql_response_ok = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"series": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "files": [], "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "files": [], "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }
@@ -67,7 +64,7 @@ graphql_response_json_error = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"series": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "files": [, "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "files": [, "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }
@@ -79,7 +76,7 @@ graphql_response_missing_required_fields = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"series": null, "exportDatetime": null, "exportLocation": null, "files": [], "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "files": [], "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }


### PR DESCRIPTION
Use the consignment level `seriesName` field instead of `series.code`
This won't make an extra DB call to get the series from the `Series` table