### PR TITLE
Temporarily remove 'body code' field

### DIFF
--- a/reporting/model.py
+++ b/reporting/model.py
@@ -11,11 +11,6 @@ class File(Type):
     metadata = Field(FileMetadata)
 
 
-class TransferringBody(Type):
-    name = Field(str)
-    tdrCode = Field(str)
-
-
 class Series(Type):
     code = Field(str)
     name = Field(str)
@@ -32,7 +27,7 @@ class Consignment(Type):
     transferInitiatedDatetime = Field(str)
     totalFiles = Field(str)
     totalFileSize = Field(str)
-    transferringBody = Field(TransferringBody)
+    transferringBodyName = Field(str)
     seriesName = Field(str)
 
 

--- a/reporting/report.py
+++ b/reporting/report.py
@@ -51,7 +51,7 @@ def get_query(cursor=None):
     node.createdDatetime()
     node.totalFiles()
     node.totalFileSize()
-    node.transferringBody()
+    node.transferringBodyName()
     node.seriesName()
     edges.cursor()
     consignments_query.page_info.__fields__('has_next_page')

--- a/reporting/report_types.py
+++ b/reporting/report_types.py
@@ -5,7 +5,7 @@ class Report:
 class StandardReport(Report):
     def __init__(self):
         self.fieldnames = [
-            "ConsignmentReference", "ConsignmentType", "TransferringBodyName", "BodyCode",
+            "ConsignmentReference", "ConsignmentType", "TransferringBodyName",
             "SeriesCode", "ConsignmentId", "UserId", "CreatedDateTime", "TransferInitiatedDatetime", "ExportDateTime",
             "ExportLocation", "FileCount", "TotalSize(Bytes)"]
 
@@ -14,8 +14,7 @@ class StandardReport(Report):
         return {
             "ConsignmentReference": node.consignmentReference,
             "ConsignmentType": node.consignmentType,
-            "TransferringBodyName": node.transferringBody.name,
-            "BodyCode": node.transferringBody.tdrCode,
+            "TransferringBodyName": node.transferringBodyName,
             "SeriesCode": node.seriesName,
             "ConsignmentId": node.consignmentid,
             "UserId": node.userid,

--- a/reporting/slack.py
+++ b/reporting/slack.py
@@ -2,7 +2,7 @@ from slack_sdk import WebClient
 
 
 def slack(emails, csv_file_path, slack_bot_token):
-    client = WebClient(token=slack_bot_token, timeout=60)
+    client = WebClient(token=slack_bot_token, timeout=180)
     print("Sending report to - ", emails)
     for email in emails:
         user_data = client.users_lookupByEmail(email=email)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -28,10 +28,7 @@ query {
         createdDatetime
         totalFiles
         totalFileSize
-        transferringBody {
-            name
-            tdrCode
-        }        
+        transferringBodyName        
         seriesName
       }
       cursor
@@ -48,7 +45,7 @@ graphql_response_ok = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "totalFiles": "0", "totalFileSize": "0", "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "totalFiles": "0", "totalFileSize": "0", "transferringBodyName": "MOCK1 Department", "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }
@@ -60,7 +57,7 @@ graphql_response_json_error = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "totalFiles": [, "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "userid": "9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70", "totalFiles": [, "transferringBodyName": "MOCK1 Department", "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }
@@ -72,7 +69,7 @@ graphql_response_missing_required_fields = b'''
   "data": {
     "consignments": {
       "edges": [
-          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "totalFiles": "0", "totalFileSize": "0", "transferringBody": {"name": "MOCK1 Department", "tdrCode": "MOCK1"}, "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
+          {"node": {"seriesName": null, "exportDatetime": null, "exportLocation": null, "totalFiles": "0", "totalFileSize": "0", "transferringBodyName": "MOCK1 Department", "consignmentid": "71c95054-74c1-4419-8864-67046c7fbbc7", "consignmentReference": "TDR-2022-C", "createdDatetime": "2022-05-10T11:43:19Z", "consignmentType": "judgment"}, "cursor": "TDR-2022-C"}
       ],
       "pageInfo": {"hasNextPage": false, "endCursor": "TDR-2022-C"}
     }
@@ -175,11 +172,10 @@ def ssm():
 
 def check_standard_report(df):
     assert len(df) == 1
-    assert len(df.columns) == 13
+    assert len(df.columns) == 12
     assert df['ConsignmentReference'][0] == 'TDR-2022-C'
     assert df['ConsignmentType'][0] == 'judgment'
     assert df['TransferringBodyName'][0] == 'MOCK1 Department'
-    assert df['BodyCode'][0] == 'MOCK1'
     assert pd.isnull(df['SeriesCode'][0]) is True
     assert df['ConsignmentId'][0] == '71c95054-74c1-4419-8864-67046c7fbbc7'
     assert df['UserId'][0] == '9ae3d9c5-8a71-4c50-9b19-b1ff4d315b70'


### PR DESCRIPTION
Retrieving 'body code' field uses a deferred resolver in the API which is a process intensive operation

Don't retrieve the 'body code' until this task is implemented: https://national-archives.atlassian.net/browse/TDR-3559 which will remove the need for a deferred resolver on the API